### PR TITLE
[TLM-1856] Remover trailing space do enum status ("PAIRED ")

### DIFF
--- a/PCM-v390.openapi.yaml
+++ b/PCM-v390.openapi.yaml
@@ -575,7 +575,7 @@ paths:
                       - ACCEPTED
                       - UNPAIRED
                       - PAIRED_INCONSISTENT
-                      - 'PAIRED '
+                      - PAIRED
                     example: ACCEPTED
                   message:
                     description: >-
@@ -1057,7 +1057,7 @@ paths:
                       - ACCEPTED
                       - UNPAIRED
                       - PAIRED_INCONSISTENT
-                      - 'PAIRED '
+                      - PAIRED
                     example: ACCEPTED
                   message:
                     description: >-


### PR DESCRIPTION
Remoção de espaço do status PAIRED:

- /report-api/v2/hybrid-flow/server/authenticated
-  /report-api/v2/hybrid-flow/client/redirect-to-server

