### PR TITLE
[TLM1860] Corrigir valores concatenados em dropReason Server ('NO_CREDENTIAL, NONE')

### DIFF
--- a/PCM-v390.openapi.yaml
+++ b/PCM-v390.openapi.yaml
@@ -4125,7 +4125,8 @@ components:
               enum:
                 - NO_AUTHORITY
                 - NO_AUTHORITY_PERSON_MISMATCH
-                - NO_CREDENTIAL, NONE
+                - NO_CREDENTIAL
+                - NONE
               example: NO_AUTHORITY
     ReportResponse:
       description: >-


### PR DESCRIPTION
Separate enums drop reason